### PR TITLE
Patch dependencies to add Hemi chain data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     types: [released]
 
 env:
-  DOCKER_IMAGE_REGISTRY: safeglobal
+  DOCKER_IMAGE_REGISTRY: hemilabs
   DOCKER_IMAGE_NAME: safe-client-gateway-nest
   DOCKER_BUILD_IMAGE_TAG: buildcache
 
@@ -112,7 +112,7 @@ jobs:
           parallel-finished: true
 
   docker-publish-staging:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/hemi-main')
     needs: [prettier, es-lint, tests-finish]
     runs-on: ubuntu-latest
     steps:
@@ -126,8 +126,8 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/build-push-action@v5
         with:
           platforms: linux/amd64,linux/arm64
@@ -155,8 +155,8 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/build-push-action@v5
         with:
           platforms: linux/amd64,linux/arm64
@@ -172,6 +172,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.DOCKER_IMAGE_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_BUILD_IMAGE_TAG }},mode=max
 
   autodeploy:
+    if: false
     runs-on: ubuntu-latest
     needs: [docker-publish-staging]
     steps:

--- a/.yarn/patches/@safe-global-safe-deployments-npm-1.36.0-59d1d00e34.patch
+++ b/.yarn/patches/@safe-global-safe-deployments-npm-1.36.0-59d1d00e34.patch
@@ -1,0 +1,108 @@
+diff --git a/dist/assets/v1.3.0/compatibility_fallback_handler.json b/dist/assets/v1.3.0/compatibility_fallback_handler.json
+index 277a53728d9b835b80d5088b52d296bbd7cb6621..216bd1c7a982e59b687c38a213b98635e3a5b103 100644
+--- a/dist/assets/v1.3.0/compatibility_fallback_handler.json
++++ b/dist/assets/v1.3.0/compatibility_fallback_handler.json
+@@ -204,6 +204,7 @@
+         "555666": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+         "622277": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+         "713715": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
++        "743111": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+         "6038361": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
+         "7225878": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
+         "7777777": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+diff --git a/dist/assets/v1.3.0/create_call.json b/dist/assets/v1.3.0/create_call.json
+index 36ee97cc389a54a1ec6e22f9a340d77298e2a30e..bfb5f847c9481058da9ae109bfbf9c6109837ff9 100644
+--- a/dist/assets/v1.3.0/create_call.json
++++ b/dist/assets/v1.3.0/create_call.json
+@@ -204,6 +204,7 @@
+         "555666": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+         "622277": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+         "713715": "0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d",
++        "743111": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+         "6038361": "0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d",
+         "7225878": "0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d",
+         "7777777": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+diff --git a/dist/assets/v1.3.0/gnosis_safe.json b/dist/assets/v1.3.0/gnosis_safe.json
+index a1b80d5ffdeac56c2639a068ef034df3b74d3947..3a2a57dc10cf6c2c9b8f5cf876f4603edd56b3ca 100644
+--- a/dist/assets/v1.3.0/gnosis_safe.json
++++ b/dist/assets/v1.3.0/gnosis_safe.json
+@@ -204,6 +204,7 @@
+         "555666": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+         "622277": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+         "713715": "0x69f4D1788e39c87893C980c06EdF4b7f686e2938",
++        "743111": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+         "6038361": "0x69f4D1788e39c87893C980c06EdF4b7f686e2938",
+         "7225878": "0x69f4D1788e39c87893C980c06EdF4b7f686e2938",
+         "7777777": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+diff --git a/dist/assets/v1.3.0/gnosis_safe_l2.json b/dist/assets/v1.3.0/gnosis_safe_l2.json
+index bd5d12b7f1fde2ba49c86110959505a019db65a8..be196ec94ba42ea499ad44f19bd1de3694929dfa 100644
+--- a/dist/assets/v1.3.0/gnosis_safe_l2.json
++++ b/dist/assets/v1.3.0/gnosis_safe_l2.json
+@@ -204,6 +204,7 @@
+         "555666": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+         "622277": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+         "713715": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
++        "743111": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+         "6038361": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+         "7225878": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+         "7777777": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+diff --git a/dist/assets/v1.3.0/multi_send.json b/dist/assets/v1.3.0/multi_send.json
+index 706ee9a58c8422e4dc5d9cc56b1a94f5d35f9fac..cf21c223d968b66e361d382304061cfd4544238d 100644
+--- a/dist/assets/v1.3.0/multi_send.json
++++ b/dist/assets/v1.3.0/multi_send.json
+@@ -204,6 +204,7 @@
+         "555666": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+         "622277": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+         "713715": "0x998739BFdAAdde7C933B942a68053933098f9EDa",
++        "743111": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+         "6038361": "0x998739BFdAAdde7C933B942a68053933098f9EDa",
+         "7225878": "0x998739BFdAAdde7C933B942a68053933098f9EDa",
+         "7777777": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+diff --git a/dist/assets/v1.3.0/multi_send_call_only.json b/dist/assets/v1.3.0/multi_send_call_only.json
+index 6ae2284996dc87f390c2380d486020daac3baf03..51e85955f947c71c9cfcc30ad1ea07f2e69b1d53 100644
+--- a/dist/assets/v1.3.0/multi_send_call_only.json
++++ b/dist/assets/v1.3.0/multi_send_call_only.json
+@@ -204,6 +204,7 @@
+         "555666": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+         "622277": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+         "713715": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
++        "743111": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+         "6038361": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
+         "7225878": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
+         "7777777": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+diff --git a/dist/assets/v1.3.0/proxy_factory.json b/dist/assets/v1.3.0/proxy_factory.json
+index 709a13a3139d349e5f08b0a6999092f31df9feac..811834133c34d642fe778aa80a4546c090d6920e 100644
+--- a/dist/assets/v1.3.0/proxy_factory.json
++++ b/dist/assets/v1.3.0/proxy_factory.json
+@@ -204,6 +204,7 @@
+         "555666": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+         "622277": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+         "713715": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
++        "743111": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+         "6038361": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+         "7225878": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+         "7777777": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+diff --git a/dist/assets/v1.3.0/sign_message_lib.json b/dist/assets/v1.3.0/sign_message_lib.json
+index ad65b01ff3e6d59b4072747c5cbaa216aa4b3c3a..3a8a2ea4fd0ce41774a6dc36512e3fde6c80cc4c 100644
+--- a/dist/assets/v1.3.0/sign_message_lib.json
++++ b/dist/assets/v1.3.0/sign_message_lib.json
+@@ -204,6 +204,7 @@
+         "555666": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+         "622277": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+         "713715": "0x98FFBBF51bb33A056B08ddf711f289936AafF717",
++        "743111": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+         "6038361": "0x98FFBBF51bb33A056B08ddf711f289936AafF717",
+         "7225878": "0x98FFBBF51bb33A056B08ddf711f289936AafF717",
+         "7777777": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+diff --git a/dist/assets/v1.3.0/simulate_tx_accessor.json b/dist/assets/v1.3.0/simulate_tx_accessor.json
+index 9785af753c5d42b1af3118b72fc5c2ee05586679..ff68d72f029c5daa7c30f2e400a4f1ab78f1f46d 100644
+--- a/dist/assets/v1.3.0/simulate_tx_accessor.json
++++ b/dist/assets/v1.3.0/simulate_tx_accessor.json
+@@ -204,6 +204,7 @@
+         "555666": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
+         "622277": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
+         "713715": "0x727a77a074D1E6c4530e814F89E618a3298FC044",
++        "743111": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
+         "6038361": "0x727a77a074D1E6c4530e814F89E618a3298FC044",
+         "7225878": "0x727a77a074D1E6c4530e814F89E618a3298FC044",
+         "7777777": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "repository": "https://github.com/5afe/safe-client-gateway-nest.git",
   "packageManager": "yarn@4.1.1",
   "resolutions": {
+    "@safe-global/safe-deployments@^1.36.0": "patch:@safe-global/safe-deployments@npm%3A1.36.0#~/.yarn/patches/@safe-global-safe-deployments-npm-1.36.0-59d1d00e34.patch",
     "postgres-shift@^0.1.0": "patch:postgres-shift@npm%3A0.1.0#./.yarn/patches/postgres-shift-npm-0.1.0-9342b5f6f6.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,12 +1569,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-deployments@npm:^1.36.0":
+"@safe-global/safe-deployments@npm:1.36.0":
   version: 1.36.0
   resolution: "@safe-global/safe-deployments@npm:1.36.0"
   dependencies:
     semver: "npm:^7.6.0"
   checksum: 10/dfcb6dc62d3c4a2c03d8aea099ac4f6155936a660c8456b88fe68867d5b8c3aca229f2583fae06cca5d1d33262dc8acfdb504ddeeccbf40bbdf600f52a819363
+  languageName: node
+  linkType: hard
+
+"@safe-global/safe-deployments@patch:@safe-global/safe-deployments@npm%3A1.36.0#~/.yarn/patches/@safe-global-safe-deployments-npm-1.36.0-59d1d00e34.patch":
+  version: 1.36.0
+  resolution: "@safe-global/safe-deployments@patch:@safe-global/safe-deployments@npm%3A1.36.0#~/.yarn/patches/@safe-global-safe-deployments-npm-1.36.0-59d1d00e34.patch::version=1.36.0&hash=b48613"
+  dependencies:
+    semver: "npm:^7.6.0"
+  checksum: 10/5368fc9184b9d49bff2cbba8171138772bb2c469e1003fee8fc1c54626c973e20c5f4fa16da8c2ab6eaa474071e109f46003a4db34e73a50b131cca043b8e128
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a `resolutions` entry to `package.json` to let Yarn apply a the proper patch to `@safe-global/safe-dependencies`. The patch modifies required files to add the addresses of the contracts deployed to Hemi Sepolia. Doing so allows building the Docker images without waiting for upstream to update the dependencies.

It also updates the Docker build pipeline to push the images to the `hemilabs` organization.